### PR TITLE
Fix Whisper FFmpeg path usage

### DIFF
--- a/modules/transcriber.py
+++ b/modules/transcriber.py
@@ -34,6 +34,11 @@ class WhisperTranscriber:
                 # Set environment variable so Whisper uses the bundled FFmpeg
                 os.environ["FFMPEG_BINARY"] = ffmpeg_path
                 self.logger.info("Using bundled FFmpeg")
+                try:
+                    # whisper.audio caches the path at import time, so update it explicitly
+                    whisper.audio.FFMPEG = ffmpeg_path
+                except Exception as e:
+                    self.logger.warning(f"Failed to update Whisper FFmpeg path: {e}")
             else:
                 self.logger.warning("FFmpeg could not be ensured; Whisper may fail if FFmpeg is missing")
         except Exception as e:


### PR DESCRIPTION
## Summary
- make sure Whisper uses the bundled FFmpeg executable by updating `whisper.audio.FFMPEG` when initializing `WhisperTranscriber`

## Testing
- `python -m py_compile modules/transcriber.py`

------
https://chatgpt.com/codex/tasks/task_e_686feb22366c8331a817844b704c99ae