### PR TITLE
Limit size of File Operations block

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -8,7 +8,8 @@ from PySide6.QtWidgets import (
     QMainWindow, QFileDialog, QMessageBox, QProgressBar,
     QComboBox, QTextBrowser, QMenu, QLineEdit, QDockWidget,
     QVBoxLayout, QHBoxLayout, QWidget, QPushButton, QSplitter,
-    QGroupBox, QLabel, QStatusBar, QListWidget, QListWidgetItem
+    QGroupBox, QLabel, QStatusBar, QListWidget, QListWidgetItem,
+    QSizePolicy
 )
 from PySide6.QtCore import QObject, Signal, QThread, Slot, Qt, QUrl
 import logging
@@ -168,6 +169,8 @@ class MainWindow(QMainWindow):
         
         # File operations
         file_group = QGroupBox("File Operations")
+        file_group.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
+        file_group.setMaximumHeight(220)
         file_layout = QVBoxLayout(file_group)
         
         self.load_video_btn = QPushButton("Load Video")


### PR DESCRIPTION
## Summary
- prevent `File Operations` panel from occupying excessive space
- import `QSizePolicy` and give the group box a max height

## Testing
- `python -m py_compile gui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68702e7278508331b81c18e6b84dd043