### PR TITLE
Move search and transcript panels to right

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -295,9 +295,9 @@ class MainWindow(QMainWindow):
         search_transcript_splitter.addWidget(transcript_group)
         search_transcript_splitter.setSizes([200, 400])
 
-        left_layout.addWidget(search_transcript_splitter)
+        left_layout.addWidget(queue_group)
 
-        right_layout.addWidget(queue_group)
+        right_layout.addWidget(search_transcript_splitter)
 
         controls_layout.addWidget(left_widget)
         controls_layout.addWidget(right_widget)


### PR DESCRIPTION
## Summary
- reposition Search Transcription and Transcription panels to the right column
- keep the Video Queue on the left column

## Testing
- `python -m py_compile gui/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_68705a0b173c83318ac6109f001d2416